### PR TITLE
devise パスワード再設定エラーの修正

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,5 @@
 class Users::PasswordsController < Devise::PasswordsController
   before_action :ensure_normal_user, only: :create
-  binding.pry
   def ensure_normal_user
     if params[:user][:email].downcase == "guest@example.com"
       redirect_to new_user_session_path, alert: "ゲストユーザーのパスワード再設定はできません。"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,9 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+  
+  # devise導入時の追記
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
https://github.com/heartcombo/devise/blob/main/README.md#getting-started


パスワードを再設定するさいにメールを送信することができなかった。
deviseのreadmeに書いてあったのでそれを追記した