### PR TITLE
thor 対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 # rails gのときの Deprecation warning 対策
-gem 'thor', '0.19.1'
+# gem 'thor', '0.19.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,7 +287,6 @@ GEM
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    thor (0.19.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
     turbolinks (5.2.1)
@@ -354,7 +353,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  thor (= 0.19.1)
   turbolinks (~> 5)
   web-console (>= 3.3.0)
   webdrivers


### PR DESCRIPTION
capistrano deployをやると

 DEBUG [4842922b]       Downloading railties-6.0.3.7 revealed dependencies not in the API or the

lockfile (thor (>= 0.20.3, < 2.0)).

のエラーが出るので直した。