### PR TITLE
listen エラー対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
-  gem 'listen', '~> 3.2'
+
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
@@ -97,3 +97,6 @@ gem 'cocoon'
 
 # サーバー環境に追加する　
 gem 'net-ssh' , '>= 6.1.0'
+
+# エラー対応のため　develop以外でも入るようにする
+gem 'listen', '~> 3.2'


### PR DESCRIPTION
rake assets:precompileのときに

LoadError: Could not load the 'listen' gem. Add `gem 'listen'` to the development group of your Gemfile

がでるのでその対応