### PR TITLE
webpack エラー修正

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,5 +1,5 @@
 const { environment } = require('@rails/webpacker')
-
+const webpack = require('webpack');
 environment.plugins.prepend('Provide',
     new webpack.ProvidePlugin({
         $: 'jquery/src/jquery',


### PR DESCRIPTION
ローカルでprecompile したら
```
/Users/kondoukou/Documents/simple-record/node_modules/webpack-cli/bin/cli.js:93
                                throw err;
                                ^

ReferenceError: webpack is not defined
```
というエラー。webpackの宣言を見直した。