### PR TITLE
ユーザー論理退会処理追加

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,6 +7,16 @@ class Users::RegistrationsController < Devise::RegistrationsController
       Genre.create!(name: "運動", user_id: @user.id)
     end
   end
+
+  # DELETE /resource
+  def destroy
+    resource.soft_delete
+    Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+    set_flash_message :notice, :destroyed
+    yield resource if block_given?
+    respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
+  end
+
   def ensure_normal_user
     if resource.email == "guest@example.com"
       redirect_to root_path, alert: "ゲストユーザーは削除できません。"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,19 @@ class User < ApplicationRecord
       user.password = SecureRandom.urlsafe_base64
     end
   end
+
+  # instead of deleting, indicate the user requested a delete & timestamp it  
+  def soft_delete  
+    update_attribute(:deleted_at, Time.current)  
+  end  
+  
+  # ensure user account is active  
+  def active_for_authentication?  
+    super && !deleted_at  
+  end  
+  
+  # provide a custom message for a deleted account   
+  def inactive_message   
+    !deleted_at ? super : :deleted_account  
+  end  
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -8,6 +8,7 @@ en:
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
       already_authenticated: "You are already signed in."
+      deleted_account: "You've deleted your account. Thanks!"  
       inactive: "Your account is not activated yet."
       invalid: "Invalid %{authentication_keys} or password."
       locked: "Your account is locked."

--- a/db/migrate/20220512200740_add_deleted_at_column_to_users.rb
+++ b/db/migrate/20220512200740_add_deleted_at_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtColumnToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_25_135339) do
+ActiveRecord::Schema.define(version: 2022_05_12_200740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 2021_09_25_135339) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
https://github.com/heartcombo/devise/wiki/How-to:-Soft-delete-a-user-when-user-deletes-account

上記URLをもとに論理退会処理を追加した。
データは無くならずに、退会される。

#297 